### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hierarchical_pathfinding"
 version = "0.5.0"
 authors = ["mich101mich <mich101mich@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Quickly approximate Paths on a Grid"
 repository = "https://github.com/mich101mich/hierarchical_pathfinding"
 readme = "readme.md"
@@ -17,15 +17,15 @@ exclude = [
 ]
 
 [dependencies]
-hashbrown = "0.11"
+hashbrown = "0.12"
 log = { version = "0.4", optional = true }   # Feature used for measuring internal timings. Recommended to leave this off unless working on improvements to hierarchical_pathfinding.
 rayon = { version = "1.5", optional = true }  # don't set this directly, use feature `parallel` instead.
 
 [dev-dependencies]
 criterion = "0.3"
-env_logger = "0.8"
+env_logger = "0.9"
 log = "0.4"
-nanorand = "0.6"
+nanorand = "0.7"
 
 [features]
 default = ["parallel"]

--- a/src/path_cache.rs
+++ b/src/path_cache.rs
@@ -1350,7 +1350,7 @@ impl<N: Neighborhood + Sync> PathCache<N> {
                     // len() - 2 because skip(1) already removes one
                     continue;
                 }
-                final_path.add_path_segment(self.nodes[*a].edges[&b].clone());
+                final_path.add_path_segment(self.nodes[*a].edges[b].clone());
             }
 
             if skip_last {


### PR DESCRIPTION
This updates
```
hashbrown 0.11 -> 0.12
env_logger 0.8 -> 0.9
nanorand  0.6 -> 0.7
```

Hashbrown and nanorand both are using edition 2021 and have an MSRV of 1.56 (1.56.1 for hashbrown).

There was a clippy warning for `warning: this expression creates a reference which is immediately dereferenced by the compiler` that I included the trivial fix for as well.